### PR TITLE
add flask_cors; stringify the name; ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 __pycache__
+venv

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -31,7 +31,7 @@ function orderCoffee(size, name, type, cb) {
     },
     body: JSON.stringify({
       query: `mutation {
-        orderCoffee(size: ${size}, name: "${name}", type: ${type}) {
+        orderCoffee(size: ${size}, name: ${JSON.stringify(name)}, type: ${type}) {
           id
           name
           type

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 ariadne==0.11.0
 click==7.1.2
 Flask==1.1.2
+Flask-Cors==3.0.8
 graphql-core==3.0.5
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
+six==1.15.0
 starlette==0.13.4
 typing-extensions==3.7.4.2
 Werkzeug==1.0.1


### PR DESCRIPTION
flask_cors was missing from the python requirements

venv is helpful to include in .gitignore

replaced the double-quoted template placeholder with stringify because the name can itself contain quotes